### PR TITLE
Import Jupyter notebook cleanup tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SRC_DIR = third_party/reimplementing-ml-papers
+include $(SRC_DIR)/Makefile

--- a/third_party/reimplementing-ml-papers/LICENSE
+++ b/third_party/reimplementing-ml-papers/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/third_party/reimplementing-ml-papers/Makefile
+++ b/third_party/reimplementing-ml-papers/Makefile
@@ -1,0 +1,42 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+VERB = @
+ifeq ($(VERBOSE),1)
+	VERB =
+endif
+
+SRC_DIR ?= .
+
+.PHONY: test clean
+
+test: nbfmt-test
+
+nbfmt-test:
+	$(VERB) echo "Notebook format tests"
+	$(VERB) echo
+	$(VERB) $(SRC_DIR)/run_nbfmt_test.sh
+
+update: nbfmt-update
+
+nbfmt-update:
+	$(VERB) $(SRC_DIR)/nbfmt_update.sh
+
+nbconvert-test:
+	$(VERB) echo "Notebook conversion tests"
+	$(VERB) echo
+	$(VERB) $(SRC_DIR)/nbconvert_test.sh
+
+datasets-test:
+	$(VERB) make -C datasets test

--- a/third_party/reimplementing-ml-papers/README.md
+++ b/third_party/reimplementing-ml-papers/README.md
@@ -1,0 +1,14 @@
+# Reimplementing ML papers
+
+This directory holds a subset of my project which aims to [reimplement ML
+papers][reimplementing-ml-papers], specifically, the tooling around simplifying
+and cleaning up Jupyter notebooks and testing them to ensure they stay that way.
+
+The file [`refresh-files.sh`](refresh-files.sh) downloads the latest versions of
+the necessary files for the functionality to be used in this repo, and something
+you can use yourself if you need the same functionality.
+
+To see how this is used, see the [top-level `Makefile`](../../Makefile) in this
+repo.
+
+[reimplementing-ml-papers]: https://github.com/mbrukman/reimplementing-ml-papers

--- a/third_party/reimplementing-ml-papers/nbfmt.py
+++ b/third_party/reimplementing-ml-papers/nbfmt.py
@@ -1,0 +1,108 @@
+#!/usr/bin/python
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Canonicalizes field ordering and values in Jupyter notebooks.
+
+This enables minimal human-reviewable diffs from one version to the next, even
+when updated in various tools like Colab, VS Code, etc., each of which make
+their own choices in various regards like field ordering, add or update
+inconsequential fields and their values, leading to spurious diffs that obscure
+the real changes.
+"""
+
+import json
+import sys
+from typing import Dict, List
+
+
+def processList(data: List):
+    """Processes the passed-in list recursively, may modify it in-place."""
+    for item in data:
+        if isinstance(item, list):
+            processList(item)
+        elif isinstance(item, dict):
+            processDict(item)
+
+
+def processDict(data: Dict):
+    """Processes the passed-in dict recursively, may modify it in-place."""
+    # Replace fields with default value `null` which aren't meaningful:
+    #
+    # * Colab doesn't load a notebook missing the `id` field.
+    # * GitHub and `nbconvert` don't load notebooks missing the
+    #   `execution_count` field.
+    for field in ('execution_count', 'id'):
+        if field in data:
+            data[field] = None
+
+    # Delete fields which don't need to be present in the notebook.
+    for field in ('base_uri', 'hash', 'outputId'):
+        if field in data:
+            del data[field]
+
+    for key in data.keys():
+        if isinstance(data[key], list):
+            processList(data[key])
+        elif isinstance(data[key], dict):
+            if key == 'kernelspec' and 'language' in data[key]:
+                del data[key]['language']
+            elif key == 'language_info' and 'version' in data[key]:
+                del data[key]['version']
+
+            processDict(data[key])
+
+    # Delete list and dict values if empty.
+    #
+    # GitHub and `nbconvert` require the following fields even if empty:
+    # `metadata`, `outputs`.
+    required_even_if_empty = ['metadata', 'outputs']
+    empty_fields_to_delete = []
+    for field in data.keys():
+        if field in required_even_if_empty:
+            continue
+        value = data[field]
+        if ((isinstance(value, list) and len(value) == 0) or
+            (isinstance(value, dict) and len(value.keys()) == 0)):
+            empty_fields_to_delete.append(field)
+
+    for field in empty_fields_to_delete:
+        del data[field]
+
+
+# TODO(mbrukman): add flag `-w` to rewrite the file in-place, a la gofmt.
+def main(argv):
+    """Parses notebook and outputs canonicalized version to stdout."""
+    if len(argv) < 2:
+        sys.stderr.write(f'Syntax: {argv[0]} [path-to-notebook]\n')
+        sys.exit(1)
+
+    notebook = argv[1]
+    json_input = None
+    with open(notebook, 'r') as json_file:
+        json_input = json.loads(json_file.read())
+
+    # Updates the JSON in-place.
+    processDict(json_input)
+
+    # Apply a few more canonicalization rules:
+    #
+    # * avoid newline at the end of file;
+    # * `sort_keys` fixes field ordering inside JSON objects;
+    # * use 2-space indent.
+    sys.stdout.write(json.dumps(json_input, sort_keys=True, indent=2))
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/third_party/reimplementing-ml-papers/nbfmt_update.sh
+++ b/third_party/reimplementing-ml-papers/nbfmt_update.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -u
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function clean_file() {
+  local file="$1"
+  local out="${file}.out"
+  local err="${file}.err"
+
+  echo -n "Updating ${file} ... "
+  if python "$(dirname $0)/nbfmt.py" "${file}" > "${out}" 2> "${err}"; then
+    # No issues; will continue with diffing `${out}` below.
+    rm "${err}"
+  else
+    echo "error:"
+    echo
+    cat "${err}"
+    echo
+    rm "${out}" "${err}"
+    return
+  fi
+
+  if diff "${file}" "${out}" > /dev/null 2>&1; then
+    rm "${out}"
+    echo "no change."
+  else
+    mv "${out}" "${file}"
+    echo "done."
+  fi
+}
+
+for file in $(find . -name \*\.ipynb | sort); do
+  clean_file "${file}"
+done

--- a/third_party/reimplementing-ml-papers/refresh-files.sh
+++ b/third_party/reimplementing-ml-papers/refresh-files.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+for file in LICENSE Makefile nbfmt.py nbfmt_update.sh run_nbfmt_test.sh ; do
+  echo "Downloading the latest version of: ${file} ..."
+  curl -sO "https://raw.githubusercontent.com/mbrukman/reimplementing-ml-papers/main/${file}"
+done
+echo "Done."

--- a/third_party/reimplementing-ml-papers/run_nbfmt_test.sh
+++ b/third_party/reimplementing-ml-papers/run_nbfmt_test.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -u
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare -i status=0
+
+function test_file() {
+  local file="$1"
+  local temp="${file}.tmp"
+  local diff="${file}.diff"
+
+  echo -n "Testing ${file} ... "
+  python "$(dirname $0)/nbfmt.py" "${file}" > "${temp}"
+  if diff -u "${file}" "${temp}" > "${diff}" 2>&1; then
+    echo "no diff."
+  else
+    status=1
+    echo "found diff:"
+    echo
+    cat "${diff}"
+    echo
+  fi
+  rm "${temp}" "${diff}"
+}
+
+for file in $(find . -name \*\.ipynb | sort); do
+  test_file "${file}"
+done
+
+echo
+if [ ${status} -eq 0 ]; then
+  echo "PASSED"
+else
+  echo "FAILED"
+fi
+
+exit ${status}


### PR DESCRIPTION
This imports the tooling I wrote previously for another of my projects: https://github.com/mbrukman/reimplementing-ml-papers to be able to clean up and simplify Jupyter notebooks which may be processed by a combination of Colab, VS Code, etc. and make sure they don't add any extraneous fields or diffs to notebooks, so that the diffs are easier to read, and the notebooks themselves are minimal.