### PR TITLE
Add GitHub Actions with Jupyter noteobok tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Checks & tests
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+        python: ['3.10']
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+    - name: Checkout the repo
+      uses: actions/checkout@v3
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python }}
+        cache: pip
+
+    - name: Install Python deps
+      run: pip install -r requirements.txt
+
+    - name: Run nbconvert test
+      run: make nbconvert-test
+
+    - name: Run notebook format test
+      run: make nbfmt-test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+jupyterlab ~= 3.5.0
+nbconvert ~= 7.2.5


### PR DESCRIPTION
Also include `nbconvert_test` from the reimplementing ML papers repo, and include the necessary Python packages to be able to test and convert notebooks.