### PR TITLE
Simplify LeNet model construction for readability

### DIFF
--- a/stackoverflow/74679315/Training_and_testing_LeNet_on_MNIST_using_Keras.ipynb
+++ b/stackoverflow/74679315/Training_and_testing_LeNet_on_MNIST_using_Keras.ipynb
@@ -267,28 +267,27 @@
       },
       "outputs": [],
       "source": [
-        "import tensorflow as tf\n",
         "from tensorflow import keras\n",
         "from keras import Input, Sequential\n",
-        "from keras.layers import Activation, AveragePooling2D, Conv2D, Dense, Flatten, Layer, MaxPooling2D\n",
+        "from keras.layers import Activation, AveragePooling2D, Conv2D, Dense, Flatten\n",
         "\n",
-        "from typing import Callable, Type\n",
         "\n",
-        "def LeNet(subsampling: Type[keras.layers.Layer] = AveragePooling2D,\n",
-        "          activation: Callable[[tf.Tensor], tf.Tensor] = keras.activations.tanh) -> Sequential:\n",
-        "    return Sequential([\n",
-        "        Input(shape=(28, 28, 1)),\n",
-        "        Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation=activation, name='C1'),\n",
-        "        subsampling(pool_size=(2, 2), strides=(2, 2), name='S2'),\n",
-        "        Activation(activation, name='S2_act'),\n",
-        "        Conv2D(filters=16, kernel_size=(5, 5), activation=activation, name='C3'),\n",
-        "        subsampling(pool_size=(2, 2), strides=(2, 2), name='S4'),\n",
-        "        Activation(activation, name='S4_act'),\n",
-        "        Conv2D(filters=120, kernel_size=(5, 5), activation=activation, name='C5'),\n",
-        "        Flatten(name='Flatten'),\n",
-        "        Dense(84, activation=activation, name='F6'),\n",
-        "        Dense(10, activation=keras.activations.softmax, name='Output'),\n",
-        "    ], name='LeNet-5')"
+        "tanh = keras.activations.tanh\n",
+        "softmax = keras.activations.softmax\n",
+        "\n",
+        "model = Sequential([\n",
+        "    Input(shape=(28, 28, 1)),\n",
+        "    Conv2D(filters=6, kernel_size=(5, 5), padding='same', activation=tanh, name='C1'),\n",
+        "    AveragePooling2D(pool_size=(2, 2), strides=(2, 2), name='S2'),\n",
+        "    Activation(tanh, name='S2_act'),\n",
+        "    Conv2D(filters=16, kernel_size=(5, 5), activation=tanh, name='C3'),\n",
+        "    AveragePooling2D(pool_size=(2, 2), strides=(2, 2), name='S4'),\n",
+        "    Activation(tanh, name='S4_act'),\n",
+        "    Conv2D(filters=120, kernel_size=(5, 5), activation=tanh, name='C5'),\n",
+        "    Flatten(name='Flatten'),\n",
+        "    Dense(84, activation=tanh, name='F6'),\n",
+        "    Dense(10, activation=softmax, name='Output'),\n",
+        "], name='LeNet-5')"
       ]
     },
     {
@@ -297,7 +296,7 @@
         "id": null
       },
       "source": [
-        "Below, we're constructing the default version of the LeNet model above, which will use the `AveragePooling2D` layer with `tanh` activation. We can also use `MaxPooling2D` layer instead, or implement the [`Subsampling`][subsampling] layer as described in the paper.\n",
+        "Above, we constructed the LeNet model using `AveragePooling2D` layer with `tanh` activation. We can also use `MaxPooling2D` layer instead, or implement the [`Subsampling`][subsampling] layer as described in the paper.\n",
         "\n",
         "[subsampling]: https://github.com/mbrukman/reimplementing-ml-papers/blob/main/lenet/subsampling.py"
       ]
@@ -346,7 +345,6 @@
         }
       ],
       "source": [
-        "model = LeNet()\n",
         "model.summary()"
       ]
     },


### PR DESCRIPTION
Remove subsampling and activation parameters, they're not very useful here, since we're not going to create many different model versions.